### PR TITLE
Add Router setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1963,6 +1963,43 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "rebay",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:4000",
   "dependencies": {
+    "axios": "^0.19.0",
     "node-sass": "^4.12.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,20 @@
 import React from 'react';
+import { BrowserRouter as Router, Route } from "react-router-dom";
+import ItemsPage from 'views/ItemsPage';
+import ItemPage from 'views/ItemPage';
 import './App.scss';
 
 function App() {
   return (
     <div className="App">
-      <header className="App-header">
+      <header className="header">
         Rebay
       </header>
+      <Router>
+        <Route path="/" exact component={ItemsPage} />
+        <Route path="/items" exact component={ItemsPage} />
+        <Route path="/item/:id" exact component={ItemPage} />
+      </Router>
     </div>
   );
 }

--- a/src/App.scss
+++ b/src/App.scss
@@ -2,32 +2,13 @@
   text-align: center;
 }
 
-.App-logo {
-  animation: App-logo-spin infinite 20s linear;
-  height: 40vmin;
-  pointer-events: none;
-}
-
-.App-header {
+.header {
   background-color: #282c34;
-  min-height: 100vh;
+  height: 60px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   font-size: calc(10px + 2vmin);
   color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
 }

--- a/src/views/ItemPage.jsx
+++ b/src/views/ItemPage.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const ItemPage = () => (
+    <h1>
+        Single Item Page
+    </h1>
+)
+
+export default ItemPage;

--- a/src/views/ItemsPage.jsx
+++ b/src/views/ItemsPage.jsx
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+
+const ItemsPage = () => {
+    const [renderedItems, setRenderedItems] = useState(null)
+
+    useEffect(() => {
+        async function fetchData() {
+            await axios.get('/api/items')
+                .then(function (response) {
+                    // handle success
+                    const createItemsComponent = (data) => {
+                        return data.map((object, index) => {
+                            return (
+                                <section key={index}>
+                                    <div>{object.title}</div>
+                                </section>
+                            )
+                        })
+                    }
+                    setRenderedItems(createItemsComponent(response.data.data))
+                })
+                .catch(function (error) {
+                    // handle error
+                    console.log(error);
+                    return error.message;
+                });
+        }
+        fetchData();
+    }, []);
+
+    return (
+        <main>
+            <h1>
+                Items Page
+            </h1>
+            <section>
+                {renderedItems}
+            </section>
+        </main>
+    )
+}
+
+export default ItemsPage;


### PR DESCRIPTION
To prove everything is setup for local development, quick and simple ItemsPage and ItemPage components were created. ItemsPage uses useEffect and axios to ensure our API call uses proxy correctly when the backend server is running locally. Now that it's proven to work, we can scrap and start again using TDD.

- All Items Page has "/" and "/items" route
- SIngle Item Page has the following route "/item/:id"
- Add a localhost:4000 proxy which will route API calls only during development. We will still need a proper setup for the base endpoint for deployment.
- Add Axios dependency to make API calls